### PR TITLE
workaround to restart worker processes

### DIFF
--- a/generatorpipeline/generatorpipeline.py
+++ b/generatorpipeline/generatorpipeline.py
@@ -28,7 +28,7 @@ __all__ = ['pipeline']
 
 class pipeline():
 
-    def __init__(self, nworkers=0, *, skipNone=True, extracache=0, verbose=False):
+    def __init__(self, nworkers=0, *, skipNone=True, extracache=0, verbose=False, maxtasksperchild=None):
         '''
         Create a pipeline decorator.
 
@@ -50,11 +50,18 @@ class pipeline():
           elements to be cached, without having additional workers.
         verbose = False,
           activate verbose print statements. For debugging only.
+        maxtasksperchild = None,
+          given to `multiprocessing.Pool`. Resets a worker after `maxtasksperchild` have
+          been completed. By using this, memory leakage, too many open file handles or otherwise
+          limited and blcked ressources can be freed again.
+          However, this only counteracts the symptoms: If you need this, your
+          decorated function (or a package it is using) is clearly programmatic garbage. 
         '''
         self.nworkers = nworkers
         self.cachelen = nworkers + extracache
         self.verbose = verbose
         self.skipNone = skipNone
+        self.maxtasksperchild = maxtasksperchild
 
     def __call__(self, func):
         '''
@@ -81,7 +88,7 @@ class pipeline():
         def return_generator_parallel(arg, **kwargs):
             if self.verbose:
                 print(f'parallel execution of "{f.__name__}" with {self.nworkers} workers.')
-            with Pool(self.nworkers) as pool:
+            with Pool(self.nworkers, maxtasksperchild=self.maxtasksperchild) as pool:
                 cache = deque()
                 for el in arg:
                     cache.append(pool.apply_async(wrapper, (el,), kwargs))

--- a/generatorpipeline/generatorpipeline.py
+++ b/generatorpipeline/generatorpipeline.py
@@ -28,7 +28,11 @@ __all__ = ['pipeline']
 
 class pipeline():
 
-    def __init__(self, nworkers=0, *, skipNone=True, extracache=0, verbose=False, maxtasksperchild=None):
+    def __init__(self, nworkers=0, *,
+                 skipNone=True,
+                 extracache=0,
+                 verbose=False,
+                 maxtasksperchild=None):
         '''
         Create a pipeline decorator.
 
@@ -55,7 +59,7 @@ class pipeline():
           been completed. By using this, memory leakage, too many open file handles or otherwise
           limited and blcked ressources can be freed again.
           However, this only counteracts the symptoms: If you need this, your
-          decorated function (or a package it is using) is clearly programmatic garbage. 
+          decorated function (or a package it is using) is clearly programmatic garbage.
         '''
         self.nworkers = nworkers
         self.cachelen = nworkers + extracache

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -25,7 +25,7 @@
 
 set -e
 
-flake8 --max-line-length=99 --show-source --statistics generatorpipeline
+pycodestyle --max-line-length=99 --show-source --statistics generatorpipeline
 nosetests . --exe
 
 ./test/benchmark.py


### PR DESCRIPTION
The newly added `maxtasksperchild` option will force a worker to restart after it has worked on that may tasks. It is directly forwarded to `multiprocessing.Pool`