### PR TITLE
Refactor to use a class instead of a closure

### DIFF
--- a/generatorpipeline/generatorpipeline.py
+++ b/generatorpipeline/generatorpipeline.py
@@ -19,6 +19,7 @@
 import functools
 from multiprocessing import Pool
 import os
+import inspect
 from collections import deque
 from .helper import isiterator
 
@@ -150,7 +151,8 @@ def pipeline(*args, **kwargs):
     return ret
 
 
-pipeline.__doc__ = Pipeline.__doc__
+pipeline.__doc__ = Pipeline.__init__.__doc__
+pipeline.__signature__ = inspect.signature(Pipeline)
 
 
 class Pipe_info():

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(name='generatorpipeline',
       author='Stephan Kuschel',
       author_email='stephan.kuschel@gmail.com',
       url='https://github.com/skuschel/generatorpipeline',
-      install_requires=['numpy'],
+      install_requires=['numpy', 'dill'],
       description='Parallelize your data-processing pipelines with just a decorator.')


### PR DESCRIPTION
This change is supposed to have more control about the behavior of the final pipeline object. It is needed for implementing operator overloading (#3 ) or to add a better output of statistics (#14)